### PR TITLE
Добавлена функция IsMetaEqual()

### DIFF
--- a/moysklad/attribute.go
+++ b/moysklad/attribute.go
@@ -20,12 +20,13 @@ type Attribute struct {
 	Type             AttributeType `json:"type,omitempty"`
 }
 
-func (a *Attribute) IsEqual(attr *Attribute) bool {
-	return a.Meta.IsEqual(attr.Meta)
-}
-
 func (a Attribute) String() string {
 	return Stringify(a)
+}
+
+// GetMeta удовлетворяет интерфейсу HasMeta
+func (a Attribute) GetMeta() *Meta {
+	return a.Meta
 }
 
 func (a Attribute) MetaType() MetaType {

--- a/moysklad/helpers.go
+++ b/moysklad/helpers.go
@@ -207,6 +207,11 @@ func Deref[T any](ptr *T) T {
 }
 
 // IsEqualPtr сравнивает значения указателей типа T
-func IsEqualPtr[T comparable](left *T, right *T) bool {
-	return Deref(left) == Deref(right)
+func IsEqualPtr[T comparable](l *T, r *T) bool {
+	return l != nil && r != nil && Deref(l) == Deref(r)
+}
+
+// IsMetaEqual сравнивает `meta.href` двух сущностей типа *T
+func IsMetaEqual[T MetaOwner](l *T, r *T) bool {
+	return l != nil && r != nil && Deref(l).GetMeta().IsEqual(Deref(r).GetMeta())
 }

--- a/moysklad/meta.go
+++ b/moysklad/meta.go
@@ -9,11 +9,15 @@ import (
 
 type HasMeta interface {
 	MetaTyper
-	GetMeta() *Meta
+	MetaOwner
 }
 
 type MetaTyper interface {
 	MetaType() MetaType
+}
+
+type MetaOwner interface {
+	GetMeta() *Meta
 }
 
 // Meta Метаданные объекта.

--- a/moysklad/moysklad.go
+++ b/moysklad/moysklad.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	Version          = "v0.0.33"
+	Version          = "v0.0.35"
 	baseApiURL       = "https://api.moysklad.ru/api/remap/1.2/"
 	defaultUserAgent = "go-moysklad/" + Version
 

--- a/moysklad/state.go
+++ b/moysklad/state.go
@@ -16,12 +16,13 @@ type State struct {
 	StateType  StateType  `json:"stateType,omitempty"`  // Тип Статуса
 }
 
-func (s *State) IsEqual(state *State) bool {
-	return s.Meta.IsEqual(state.Meta)
-}
-
 func (s State) String() string {
 	return Stringify(s)
+}
+
+// GetMeta удовлетворяет интерфейсу HasMeta
+func (s State) GetMeta() *Meta {
+	return s.Meta
 }
 
 type States = Slice[State]


### PR DESCRIPTION
- Принимает два указателя типа `T`, которые удовлетворяют интерфейсу `MetaOwner` и производит сравнение `Meta` этих двух сущностей по полю `Href`
- Если один из аргументов будет `nil` -> вернёт `false`
- Если оба аргумента будут `nil` -> вернёт `false`